### PR TITLE
fix: Prisma client side enum error

### DIFF
--- a/src/routes/account/new-listing/+page.server.ts
+++ b/src/routes/account/new-listing/+page.server.ts
@@ -2,10 +2,10 @@ import { auth } from '$lib/auth';
 import { error, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from '../$types';
 import { categories } from '$lib/types/category';
-import type { Condition } from '@prisma/client';
 import { put } from '@vercel/blob';
 import { prisma } from '$lib/server/prisma';
 import sharp from 'sharp';
+import type { Condition } from '@prisma/client';
 
 // This is needed so the server hooks can run for authenticated routes
 export const load: PageServerLoad = async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,22 @@ import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'url';
+
+function getModulePath(moduleName: string) {
+	try {
+		const moduleUrl = import.meta.resolve(moduleName);
+		const modulePath = fileURLToPath(moduleUrl);
+		return (
+			modulePath.substring(0, modulePath.lastIndexOf('node_modules')).replace(/\/+$/, '') || ''
+		);
+	} catch (error) {
+		console.error(`Module ${moduleName} resolution failed:`, (error as Error).message);
+		return '';
+	}
+}
+
+const prismaNodeModulesPath = `${getModulePath('@prisma/client')}/node_modules`;
 
 export default defineConfig({
 	plugins: [
@@ -10,5 +26,10 @@ export default defineConfig({
 		Icons({
 			compiler: 'svelte'
 		})
-	]
+	],
+	resolve: {
+		alias: {
+			'.prisma/client/index-browser': `${prismaNodeModulesPath}/.prisma/client/index-browser.js`
+		}
+	}
 });


### PR DESCRIPTION
For some reason, prisma does not work well with enums in the browser, this is an ongoing issue and the change the the vite config is what most people have found as a fix.

Related [issue](https://github.com/prisma/prisma/issues/12504#issuecomment-1136126199)